### PR TITLE
Allow saving files to have default filenames

### DIFF
--- a/api/src/main/java/jnafilechooser/api/WindowsFileChooser.java
+++ b/api/src/main/java/jnafilechooser/api/WindowsFileChooser.java
@@ -204,7 +204,7 @@ public class WindowsFileChooser
 		// 4 bytes per char + 1 null byte
 		final int bufferSize = 4 * bufferLength + 1;
 		params.lpstrFile = new Memory(bufferSize);
-		if (open & !defaultFilename.isEmpty()) {
+		if (!defaultFilename.isEmpty()) {
 			params.lpstrFile.setWideString(0, defaultFilename);
 		} else {
 		    params.lpstrFile.clear(bufferSize);


### PR DESCRIPTION
The original implementation only allowed *opening* files to implement default filenames. This removes an arbitrary limiter and allows *saving* files to also open the prompt with default filenames pretyped. Tested and seems to function properly. Not sure if there was some technical reason for seemingly "arbitrary" limiter.