### PR TITLE
add native file dialogs for mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JnaFileChooser
 
 This is a small API that uses the native file chooser and folder browser 
-dialogs on Windows if possible. It falls back to the Swing JFileChooser 
+dialogs on Windows and Mac OS if possible. It falls back to the Swing JFileChooser 
 class if necessary.
 
 ## Example Usage

--- a/api/src/main/java/jnafilechooser/api/JnaFileChooser.java
+++ b/api/src/main/java/jnafilechooser/api/JnaFileChooser.java
@@ -246,14 +246,13 @@ public class JnaFileChooser
 
 	private boolean showMacFileChooser(Frame parent, Action action) {
 		int mode = action == Action.Open ? FileDialog.LOAD : FileDialog.SAVE;
-		String title = action == Action.Open ? "Open" : "Save";
+		String title = !dialogTitle.isEmpty() ?
+				dialogTitle : (action == Action.Open ? "Open" : "Save As");
 		FileDialog fd = new FileDialog(parent, title, mode);
 		fd.setMultipleMode(multiSelectionEnabled);
 
 		if (!defaultFile.isEmpty())
 			fd.setFile(defaultFile);
-		if (!dialogTitle.isEmpty())
-			fd.setTitle(dialogTitle);
 
 		if (currentDirectory != null) {
 			if (currentDirectory.isDirectory())
@@ -269,12 +268,12 @@ public class JnaFileChooser
 			// filterSpec is formatted as [ name, ext1, ext2, ext3, ... ]
 			for (String[] filterSpec : filters) {
 				for (int i = 1; i < filterSpec.length; i++) {
-					String filter = filterSpec[i];
+					String filter = filterSpec[i].toLowerCase();
 					if (filter.startsWith("*")) {
-						if (filename.endsWith(filter.substring(1)))
+						if (filename.toLowerCase().endsWith(filter.substring(1)))
 							return true;
 					} else {
-						if (filename.endsWith(filter))
+						if (filename.toLowerCase().endsWith(filter))
 							return true;
 					}
 				}
@@ -295,7 +294,8 @@ public class JnaFileChooser
 	}
 
 	public boolean showMacFolderBrowser(Frame parent) {
-		FileDialog fd = new FileDialog(parent, "Open", FileDialog.LOAD);
+		String title = !dialogTitle.isEmpty() ? dialogTitle : "Open";
+		FileDialog fd = new FileDialog(parent, title, FileDialog.LOAD);
 		if (!dialogTitle.isEmpty())
 			fd.setTitle(dialogTitle);
 

--- a/api/src/main/java/jnafilechooser/api/JnaFileChooser.java
+++ b/api/src/main/java/jnafilechooser/api/JnaFileChooser.java
@@ -269,8 +269,14 @@ public class JnaFileChooser
 			// filterSpec is formatted as [ name, ext1, ext2, ext3, ... ]
 			for (String[] filterSpec : filters) {
 				for (int i = 1; i < filterSpec.length; i++) {
-					if (filename.endsWith(filterSpec[i]))
-						return true;
+					String filter = filterSpec[i];
+					if (filter.startsWith("*")) {
+						if (filename.endsWith(filter.substring(1)))
+							return true;
+					} else {
+						if (filename.endsWith(filter))
+							return true;
+					}
 				}
 			}
 			return false;


### PR DESCRIPTION
Supports #16 

Hi, thanks for creating this project, I found it very helpful for use on Windows. I thought it would be a good idea to also extend the functionality to support native file and folder browsing dialogs for Mac OS. I added support for Mac via AWT's `FileDialog` class.

## Changes
- added `showMacFileChooser` and `showMacFolderBrowser` methods to `JnaFileChooser`, which are now called by `showDialog` if the platform is Mac.

## Demo Images
I put together a demo app to showcase the functionality on Mac, here are some screenshots:

#### file selection, single select
![jnafilechooser-mac-singlefile](https://github.com/user-attachments/assets/6c2dd036-62f1-4fb3-b378-d05a38f63b17)

#### file selection, multi select
![jnafilechooser-mac-multifile](https://github.com/user-attachments/assets/4db2c8d6-2cda-43ba-ab24-d626543ced4d)

#### file save
![jnafilechooser-mac-savefile](https://github.com/user-attachments/assets/7440d31a-284e-4c54-adc7-dc0021d48baf)

#### folder select
![jnafilechooser-mac-folder](https://github.com/user-attachments/assets/61011dd8-4101-475d-b070-d1e411a8c768)
